### PR TITLE
POST preview with sha param 

### DIFF
--- a/whedon_api.rb
+++ b/whedon_api.rb
@@ -480,7 +480,8 @@ class WhedonApi < Sinatra::Base
   # repo it calls a worker and then redirects to get get preview page
   # below, passing in the worker job_id
   post '/preview' do
-    sha = SecureRandom.hex
+    # sha = SecureRandom.hex
+    sha = params.has_key?(:sha)? params[:sha] : SecureRandom.hex 
     logger.info journals
     # params example {"repository"=>"https://github.com/brayanrodbajo/Deleteme", "branch"=>"patch-1", "journal"=>"biohackrxiv", "commit"=>"Compile paper"}
     logger.info params


### PR DESCRIPTION
I believe that, in case of a request from an external app, knowing the sha assigned to the repository is necessary to be able to download the PDF with this service. However, to get the PDF, the problem will be that the app has to do a GET request to /preview?id=sha when the status is complete. 